### PR TITLE
cleanup ci: remove branch push trigger

### DIFF
--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - ci-auth
 
 permissions: {}
 


### PR DESCRIPTION
This was useful while iterating on #15 but it's not needed anymore

needs https://github.com/chainguard-dev/mono/pull/29505 since PR tokens come with `:pull_request`