### PR TITLE
GitHub Actions security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -23,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.x"

--- a/.github/workflows/auth.yml
+++ b/.github/workflows/auth.yml
@@ -35,7 +35,7 @@ jobs:
     - uses: chainguard-dev/setup-chainctl@2cddd35a2f120d9973e58094dc6878c93cf58c28 # v0.5.1
       with:
         identity: ${{ env.CHAINGUARD_IDENTITY }}
-    - run: chainctl auth login --audience=libraries.cgr.dev --identity=${{ env.CHAINGUARD_IDENTITY }}
+    - run: chainctl auth login --audience=libraries.cgr.dev --identity="${CHAINGUARD_IDENTITY}"
 
     - name: Use keyring to install private packages
       run: python3 -m pip install --index-url https://libraries.cgr.dev/python/simple/ ansi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.x"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,15 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # Clone the repository
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: 🔬 Execute all unit tests
       run: |
-        python3 -m pip install -e .[testing]
+        python3 -m pip install -e ".[testing]"
         python3 -m pytest tests/test_chainctl_auth.py -v
 
     - name: 🛠️ Build package and source distribution

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,15 @@ name: 🏗️ Build & release package
 
 on: push
 
+permissions: {}
+
 jobs:
   build:
     name: 📦 Build and test package
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # Clone the repository
 
     steps:
     - name: 🛒 Checkout repository source code

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+rules:
+  # Paired with `cooldown.default-days: 3` in .github/dependabot.yml.
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Cosmetic pedantic-only findings — suppressed across the campaign.
+  anonymous-definition:
+    disable: true
+  undocumented-permissions:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION
## Summary

A set of GitHub Actions security-hardening changes surfaced by a `zizmor` audit
of `.github/`. No behavioral change to CI, the auth test, or releases.

## Changes

- **`ci.yml`, `release.yml`** — set least-privilege `permissions`: a
  workflow-level `permissions: {}` plus the minimal per-job grants each job
  actually needs, so jobs no longer inherit the broad default `GITHUB_TOKEN`
  scopes. (release.yml's publish jobs keep their own `id-token: write` for
  trusted publishing.)

- **`auth.yml`, `ci.yml`** — set `persist-credentials: false` on the
  `actions/checkout` steps that have no downstream git writes, so the
  `GITHUB_TOKEN` isn't left in the local git config for later steps to read.

- **`auth.yml`** — pass the Chainguard identity to the `chainctl` step via a
  job-level `env:` reference rather than interpolating `${{ ... }}` directly
  into the `run:` script (template-injection hardening; the value is unchanged).

- **`.github/zizmor.yml` + `.github/dependabot.yml`** — disable the cosmetic
  pedantic-persona rules and add a 3-day Dependabot `cooldown` (with the matching
  `zizmor` threshold); the `zizmor` workflow's `paths:` are extended to cover
  both config files.

## Testing

- `zizmor` and `actionlint`: no new findings introduced by these changes
  (one pre-existing `actionlint` SC2102 note in `release.yml` is unrelated and
  left as-is).
- Patches apply cleanly on top of `main`; all workflows still parse.
- Independently reviewed by a second pass: no blocking issues.

Refs: PSEC-923